### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/adcaudill/phosphor-notes/security/code-scanning/1](https://github.com/adcaudill/phosphor-notes/security/code-scanning/1)

In general, fix this by explicitly specifying a `permissions` block either at the top level of the workflow (applies to all jobs unless overridden) or within the specific job. For a pure build workflow that only needs to read the repository contents, the least privilege configuration is `permissions: contents: read`.

The best minimal fix here without changing functionality is to add a `permissions` block at the workflow root, just under `name: Build`. This will constrain the GITHUB_TOKEN for all jobs in this workflow to read-only repository contents, which is sufficient for `actions/checkout` and does not affect the build and packaging steps. No imports or additional methods are needed; this is a pure YAML configuration change in `.github/workflows/build.yml`.

Concretely:
- Edit `.github/workflows/build.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 1 (`name: Build`) and line 3 (`on:`), shifting subsequent lines down. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
