### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests on ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/adcaudill/phosphor-notes/security/code-scanning/2](https://github.com/adcaudill/phosphor-notes/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level or per job) to limit the `GITHUB_TOKEN` to the minimal access required. For this test workflow, all steps only need to read the repository contents (for checkout) and do not need to write to the repo, issues, or pull requests. `actions/upload-artifact` uses the workflow run’s own storage and does not require repository write permissions. Therefore, we can set `contents: read` as the only permission.

The best minimal fix, without changing existing behavior, is to add a `permissions` block at the workflow root, between the `on:` block and the `jobs:` block, in `.github/workflows/tests.yml`. This will apply to all jobs (currently just `test`) and ensure they only get read access to repository contents. No additional imports, methods, or other definitions are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
